### PR TITLE
Add `/workspace` to `PYTHONPATH`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,7 +103,7 @@ RUN printf "\
 \n# source ${vhls}/Vitis_HLS/\$XLNX_VERSION/settings64.sh \
 \n# MLIR-AIE PATH setup \
 \nexport PATH=/srcPkgs/cmake/bin:/workspace/hls/build/bin:/workspace/llvm/build/bin:/workspace/mlir-aie/install/bin:/workspace/mlir-air/install/bin:\$PATH \
-\nexport PYTHONPATH=/workspace/machop:/workspace/mlir-aie/install/python:/workspace/mlir-air/install/python:\$PYTHONPATH \
+\nexport PYTHONPATH=/workspace:/workspace/machop:/workspace/mlir-aie/install/python:/workspace/mlir-air/install/python:\$PYTHONPATH \
 \nexport LD_LIBRARY_PATH=/workspace/mlir-aie/lib:/workspace/mlir-air/lib:/opt/xaiengine:\$LD_LIBRARY_PATH \
 \n# Thread setup \
 \nexport nproc=\$(grep -c ^processor /proc/cpuinfo) \


### PR DESCRIPTION
Not sure if want to move where `mase_cocotb/` folder is on the `mase-tools` repo, but we need to add the root of the workspace if we want imports like `from mase_cocotb.runner import mase_runner` to work for now.

It will also help any python file to reference and import another one in the project if we put the root on the path.