### PR TITLE
added pip install mpmath==1.3.0 to fix issue with quantized modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,6 +90,7 @@ RUN pip3 install --pre torchvision --extra-index-url https://download.pytorch.or
                     pytest-cov pytest-xdist pytest-sugar pytest-html \
                     lightning \
     && pip install -U Pillow
+    && pip install mpmath==1.3.0 
 
 # Add environment variables
 ARG VHLS_PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,7 @@ RUN pip3 install --pre torchvision --extra-index-url https://download.pytorch.or
                     ghp-import optimum pytest-profiling myst_parser \
                     pytest-cov pytest-xdist pytest-sugar pytest-html \
                     lightning \
-    && pip install -U Pillow
+    && pip install -U Pillow \
     && pip install mpmath==1.3.0 
 
 # Add environment variables


### PR DESCRIPTION
The traceback started from importing the quantized modules. I don't think its an issue with Mase but one with other libraries.

Here is a github issue I found about it, https://github.com/NVIDIA/TensorRT-LLM/issues/1145 --> https://github.com/YanWenKun/ComfyUI-Docker/issues/20

